### PR TITLE
Increase polling frequency when fetching for messages

### DIFF
--- a/src/main/java/com/github/themeetgroup/kafka/connect/rabbitmq/source/RabbitMQSourceTask.java
+++ b/src/main/java/com/github/themeetgroup/kafka/connect/rabbitmq/source/RabbitMQSourceTask.java
@@ -99,7 +99,7 @@ public class RabbitMQSourceTask extends SourceTask {
     List<SourceRecord> batch = new ArrayList<>(4096);
 
     while (!this.records.drain(batch)) {
-      Thread.sleep(1000);
+      Thread.sleep(100);
     }
 
     return batch;


### PR DESCRIPTION
We are seeing ~1s delay in processing messages in staging/prod that come from RabbitMQ. It seems this might be the culprit as we are introducing a hardcoded 1s delay between polls.

This could be made configurable but 100ms is the default for kafka consumers, so it feels like a more natural starting point.